### PR TITLE
README: fixup some IoT references

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,7 +8,7 @@ See the [Fedora IoT documentation](https://docs.fedoraproject.org/en-US/iot/).
 
 ## Getting help and discussion spaces
 
-- The [#fedora-iot:fedoraproject.org channel on Matrix](https://matrix.to/#/#fedora-iot:fedoraproject.org) or libera.chat/fedora-iot on IRC (irc://irc.libera.chat/fedora-iot) channels. The channels are bridged: joining either one will let you talk to everyone.
+- The [#iot:fedoraproject.org channel on Matrix](https://matrix.to/#/#iot:fedoraproject.org) or libera.chat/fedora-iot on IRC (irc://irc.libera.chat/fedora-iot) channels. The channels are bridged: joining either one will let you talk to everyone.
 - Ask questions using the [#iot tag on discussion.fedoraproject.org](https://discussion.fedoraproject.org/tag/iot).
 
 ## Reporting issues
@@ -25,7 +25,7 @@ We also have a [RHBZ Tracker bug](https://bugzilla.redhat.com/show_bug.cgi?id=12
 
 ## Related projects
 
-The following projects use the same technologies as Fedora Silverblue:
+The following projects use the same technologies as Fedora IoT:
 
 - [Fedora CoreOS](https://getfedora.org/coreos)
 - [Fedora Silverblue](https://fedoraproject.org/silverblue/)


### PR DESCRIPTION
- #fedora-iot on the Matrix server doesn't exist; #iot appears to be the right channel name
- copy/paste fixup